### PR TITLE
Fixed: Raid timer alterations weren't taking effect. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # All-in-One
 All in one mod for Jet 12.8 and forwards
 
+7-dec-2020 Update 2.0.9
+
+	-fixed raid timer bug
 
 3-dec-2020 Update 2.0.8:
 

--- a/mod.config.json
+++ b/mod.config.json
@@ -1,7 +1,7 @@
 {
     "name": "AllinOne",
     "author": "Jugador123",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "license": "MIT",
         "autoUpdate": true,
         "checkUpdateUrl": "https://raw.githubusercontent.com/JUGADOR123/All-in-One/main/updater.json",

--- a/src/timer.js
+++ b/src/timer.js
@@ -4,6 +4,7 @@ exports.mod = () => {
         let file = fileIO.readParsed(db.user.cache.locations)
         for (let map in file) {
             file[map].base.exit_access_time = settings.gameplay.raidTimer;
+            file[map].base.escape_time_limit = settings.gameplay.raidTimer;
         }
         fileIO.write(db.user.cache.locations, file);
         logger.logSuccess("[Mod Aio] Raids have been extended");

--- a/updater.json
+++ b/updater.json
@@ -1,7 +1,7 @@
 {
     "name": "AllinOne",
     "author": "Jugador123",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "forceDowngrade": false,
     "downloadUpdateUrl": "https://codeload.github.com/JUGADOR123/All-in-One/zip/main",
     "excludeFromUpdate": []


### PR DESCRIPTION
Needed to modify exit availability timer and the max raid timer.